### PR TITLE
Fix travis build for api version 26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,8 @@ android:
     # Latest artifacts in local repository
     - extra-google-m2repository
     - extra-android-m2repository
-    - android-sdk-license-.+
-    - '.+'
     # Specify at least one system image
     - sys-img-armeabi-v7a-android-$EMULATOR_API_LEVEL
-
-licenses:
-    - 'android-sdk-preview-license-.+'
-    - 'android-sdk-license-.+'
-    - 'google-gdk-license-.+'
 
 before_script:
   - echo no | android create avd --force -n test -t android-$EMULATOR_API_LEVEL --abi armeabi-v7a

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,19 @@ jdk:
 
 env:
   global:
-    - ANDROID_API_LEVEL=25
-    - ANDROID_API_LEVEL_22=22
-    - ANDROID_BUILD_TOOLS_VERSION=25.0.3
+    - ANDROID_API_LEVEL=26
+    - EMULATOR_API_LEVEL=22
+    - ANDROID_BUILD_TOOLS_VERSION=26.0.0
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
-    - ANDROID_TARGET=android-25
+    - ANDROID_TARGET=android-$ANDROID_API_LEVEL
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 android:
   components:
     - tools
     - platform-tools
-    - android-$ANDROID_API_LEVEL_22
+    - android-$EMULATOR_API_LEVEL
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION
     - android-$ANDROID_API_LEVEL
     # For Google APIs
@@ -32,15 +32,7 @@ android:
     - android-sdk-license-.+
     - '.+'
     # Specify at least one system image
-    - sys-img-armeabi-v7a-google_apis-$ANDROID_API_LEVEL
-    - sys-img-armeabi-v7a-android-$ANDROID_API_LEVEL_22
-
-# list of directories to Cache
-
-before_install:
-  - mkdir "$ANDROID_HOME/licenses" || true
-  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
-  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+    - sys-img-armeabi-v7a-android-$EMULATOR_API_LEVEL
 
 licenses:
     - 'android-sdk-preview-license-.+'
@@ -48,7 +40,7 @@ licenses:
     - 'google-gdk-license-.+'
 
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-$EMULATOR_API_LEVEL --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &


### PR DESCRIPTION
Travis build started failing from [build#41](https://travis-ci.org/bufferapp/android-clean-architecture-boilerplate/builds/301862485#L3060). This is because after [build#40](https://travis-ci.org/bufferapp/android-clean-architecture-boilerplate/builds/282336878#L3059) `26.0.0` was released and `26.0.0-beta2` started downloading `26.0.0` instead of the beta version.

This PR updates the `.travis.yml` file to use android api 26 instead of 25. As [api version in travis should match that in build.gradle](https://github.com/travis-ci/travis-ci/issues/6670)