### PR TITLE
Upgrade gradle version to 3.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.dicedmelon.gradle:jacoco-android:0.1.1"
 

--- a/cache/build.gradle
+++ b/cache/build.gradle
@@ -5,7 +5,6 @@ android {
     def globalConfiguration = rootProject.extensions.getByName("ext")
 
     compileSdkVersion globalConfiguration["androidCompileSdkVersion"]
-    buildToolsVersion globalConfiguration["androidBuildToolsVersion"]
 
     defaultConfig {
         minSdkVersion globalConfiguration["androidMinSdkVersion"]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,6 @@ allprojects {
 
 ext {
     //Android
-    androidBuildToolsVersion = "26.0.0"
     androidMinSdkVersion = 15
     androidTargetSdkVersion = 26
     androidCompileSdkVersion = 26

--- a/mobile-ui/build.gradle
+++ b/mobile-ui/build.gradle
@@ -8,7 +8,6 @@ android {
     def globalConfiguration = rootProject.extensions.getByName("ext")
 
     compileSdkVersion globalConfiguration["androidCompileSdkVersion"]
-    buildToolsVersion globalConfiguration["androidBuildToolsVersion"]
 
     defaultConfig {
         minSdkVersion globalConfiguration["androidMinSdkVersion"]


### PR DESCRIPTION
Upgrade gradle version to 3.0.1

In this we are also removing the androidBuildToolsVersion. When upgrading
gradle, this warning was given:

>Warning:The specified Android SDK Build Tools version (26.0.0) is ignored, as
it is below the minimum supported version (26.0.2) for Android Gradle Plugin
3.0.1.  Android SDK Build Tools 26.0.2 will be used. To suppress this warning,
remove "buildToolsVersion '26.0.0'" from your build.gradle file, as each
version of the Android Gradle Plugin now has a default version of the build
tools.

Because the version of build tools now has a default, it doesn't need to be
specified.