### PR TITLE
Clean up dependencies.gradle

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,9 +8,6 @@ ext {
 
     //Libraries
     kotlinVersion = '1.1.3-2'
-    butterKnifeVersion = '7.0.1'
-    recyclerViewVersion = '21.0.3'
-    rxJavaVersion = '2.0.2'
     rxKotlinVersion = '2.1.0'
     rxAndroidVersion = '2.0.1'
     javaxAnnotationVersion = '1.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,4 @@
 
-allprojects {
-    repositories {
-        jcenter()
-    }
-}
-
 ext {
     //Android
     androidBuildToolsVersion = "26.0.0"


### PR DESCRIPTION
It seems like there is no need to add jcenter to the repositories here?
In build.gradle it is added anyway, alongside the google one:

```
allprojects {
    repositories {
        google()
        jcenter()
    }
}
```